### PR TITLE
fix datetimeconverter error (populate, convert timestamp)

### DIFF
--- a/autoinsight_helpers/feature_engineering/datetime64_converter.py
+++ b/autoinsight_helpers/feature_engineering/datetime64_converter.py
@@ -25,6 +25,7 @@ class AutoinsightDatetime64Converter(BaseEstimator, TransformerMixin):
                 format=self.datetime_format,
                 errors='coerce'
             )
+            target_column = X.loc[:, cn]
         else:
             def _parse(x):
                 try:
@@ -36,6 +37,7 @@ class AutoinsightDatetime64Converter(BaseEstimator, TransformerMixin):
                     ret = datetime.fromtimestamp(0)
                 return ret
             X.loc[:, cn] = target_column.map(lambda x: _parse(x))
+            target_column = X.loc[:, cn]
         if self.populate_features:
             idx = X.columns.get_loc(cn)
             X.insert(idx + 1, cn + '_year', X[cn].dt.year)
@@ -44,15 +46,16 @@ class AutoinsightDatetime64Converter(BaseEstimator, TransformerMixin):
             X.insert(idx + 4, cn + '_day', X[cn].dt.day)
             X.insert(idx + 5, cn + '_hour', X[cn].dt.hour)
             X.insert(idx + 6, cn + '_minute', X[cn].dt.minute)
-            X.insert(idx + 7, cn + '_dayofweek', X[cn].dt.dayofweek)
-            X = X.drop(cn, axis=1)
+            X.insert(idx + 7, cn + '_second', X[cn].dt.second)
+            X.insert(idx + 8, cn + '_dayofweek', X[cn].dt.dayofweek)
+            X = X.drop(columns=[cn])
 
         if self.convert_timestamp:
-            X.loc[:, cn] = X.loc[:, cn].map(lambda x: time.mktime(
+            X.loc[:, cn] = target_column.map(lambda x: time.mktime(
                 x.timetuple()
             ))
 
-        if (self.populate_features and self.convert_timestamp) is False:
+        if (self.populate_features or self.convert_timestamp) is False:
             X.loc[:, cn] = target_column
 
         return X

--- a/autoinsight_helpers/feature_engineering/datetime64_converter.py
+++ b/autoinsight_helpers/feature_engineering/datetime64_converter.py
@@ -25,6 +25,7 @@ class AutoinsightDatetime64Converter(BaseEstimator, TransformerMixin):
                 format=self.datetime_format,
                 errors='coerce'
             )
+            target_column = X.loc[:, cn]
         else:
             def _parse(x):
                 try:
@@ -44,15 +45,16 @@ class AutoinsightDatetime64Converter(BaseEstimator, TransformerMixin):
             X.insert(idx + 4, cn + '_day', X[cn].dt.day)
             X.insert(idx + 5, cn + '_hour', X[cn].dt.hour)
             X.insert(idx + 6, cn + '_minute', X[cn].dt.minute)
-            X.insert(idx + 7, cn + '_dayofweek', X[cn].dt.dayofweek)
-            X = X.drop(cn, axis=1)
+            X.insert(idx + 7, cn + '_second', X[cn].dt.second)
+            X.insert(idx + 8, cn + '_dayofweek', X[cn].dt.dayofweek)
+            X = X.drop(columns=[cn])
 
         if self.convert_timestamp:
-            X.loc[:, cn] = X.loc[:, cn].map(lambda x: time.mktime(
+            X.loc[:, cn] = target_column.map(lambda x: time.mktime(
                 x.timetuple()
             ))
 
-        if (self.populate_features and self.convert_timestamp) is False:
+        if (self.populate_features or self.convert_timestamp) is False:
             X.loc[:, cn] = target_column
 
         return X


### PR DESCRIPTION
1. populate 초 단위 추가 
2. populate, timestamp 기능 문제 
populate 할 때 원래 drop으로 원본 컬럼 삭제되도록 해놓았는데,
```
if (self.populate_features and self.convert_timestamp) is False:
    X.loc[:, cn] = target_column
```
이 조건문 때문에 다시 원래 컬럼이 생기는 것 같았습니다. populate, convert_timestamp 둘 다 안하고 넘어갈 경우 원래 컬럼으로 복구하려는 기능 같은데 그러려면 and가 아니고 or여야 합니다. (True and False -> False, True or False -> True)
timestamp 변환이 안되던 것도 얘가 원상복구 시켜서인 것 같습니다.
