### PR TITLE
datetime64_converter 수정

### DIFF
--- a/autoinsight_helpers/feature_engineering/datetime64_converter.py
+++ b/autoinsight_helpers/feature_engineering/datetime64_converter.py
@@ -56,6 +56,6 @@ class AutoinsightDatetime64Converter(BaseEstimator, TransformerMixin):
             ))
 
         if not self.populate_features and not self.convert_timestamp:
-            X.loc[:, cn] = target_column
+            X.loc[:, cn] = target_column.astype('object')
 
         return X

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_namespace_packages
 setup(
     name="autoinsight_helpers",
-    version="1.0.4",
+    version="1.0.5",
     packages=find_namespace_packages(),
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_namespace_packages
 setup(
     name="autoinsight_helpers",
-    version="1.0.5",
+    version="1.0.6",
     packages=find_namespace_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
datetime64_converter - change the datetime column back to object if unused

https://github.com/happytk/autoinsight/issues/646에 나온 얘기처럼
아무 처리도 안 한 datetime이 그대로 넘어가는 경우 모델에서 제대로 처리가 안되기에,
다시 object dtype으로 돌려놓습니다. (그냥 object처럼 integer_encoder로 처리되도록)