### PR TITLE
IntegerEncode unseen value exception

### DIFF
--- a/accutuning_helpers/preprocessing/integerencode.py
+++ b/accutuning_helpers/preprocessing/integerencode.py
@@ -3,9 +3,10 @@ from .ordinalencoder_tmp import OrdinalEncoder
 
 
 class AccutuningIntegerEncode(BaseEstimator, TransformerMixin):
-    def __init__(self):
-        self.oe = OrdinalEncoder(handle_unknown='use_encoded_value', unknown_value=-1)
+    def __init__(self, unknown_value=-1):
         self.columns_to_encode = list()
+        self.unknown_value = unknown_value
+        self.oe = OrdinalEncoder(handle_unknown='use_encoded_value', unknown_value=self.unknown_value)
 
     def fit(self, X, y=0, **fit_params):
         self.columns_to_encode = list(

--- a/accutuning_helpers/preprocessing/integerencode.py
+++ b/accutuning_helpers/preprocessing/integerencode.py
@@ -1,10 +1,10 @@
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.preprocessing import OrdinalEncoder
+from .ordinalencoder_tmp import OrdinalEncoder
 
 
 class AccutuningIntegerEncode(BaseEstimator, TransformerMixin):
     def __init__(self):
-        self.oe = OrdinalEncoder()
+        self.oe = OrdinalEncoder(handle_unknown='use_encoded_value', unknown_value=-1)
         self.columns_to_encode = list()
 
     def fit(self, X, y=0, **fit_params):

--- a/accutuning_helpers/preprocessing/ordinalencoder_tmp.py
+++ b/accutuning_helpers/preprocessing/ordinalencoder_tmp.py
@@ -1,0 +1,610 @@
+# Temporarily use sklearn.preprocessing.OrdinalEncoder from sklearn==0.24.0
+
+from sklearn.base import BaseEstimator, TransformerMixin
+
+import numbers
+from sklearn.utils import check_array
+from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.validation import _deprecate_positional_args
+
+from typing import NamedTuple
+
+import numpy as np
+
+def is_scalar_nan(x):
+    """Tests if x is NaN.
+    This function is meant to overcome the issue that np.isnan does not allow
+    non-numerical types as input, and that np.nan is not float('nan').
+    Parameters
+    ----------
+    x : any type
+    Returns
+    -------
+    boolean
+    Examples
+    --------
+    >>> is_scalar_nan(np.nan)
+    True
+    >>> is_scalar_nan(float("nan"))
+    True
+    >>> is_scalar_nan(None)
+    False
+    >>> is_scalar_nan("")
+    False
+    >>> is_scalar_nan([np.nan])
+    False
+    """
+    # convert from numpy.bool_ to python bool to ensure that testing
+    # is_scalar_nan(x) is True does not fail.
+    return bool(isinstance(x, numbers.Real) and np.isnan(x))
+
+
+def _unique(values, *, return_inverse=False):
+    """Helper function to find unique values with support for python objects.
+    Uses pure python method for object dtype, and numpy method for
+    all other dtypes.
+    Parameters
+    ----------
+    values : ndarray
+        Values to check for unknowns.
+    return_inverse : bool, default=False
+        If True, also return the indices of the unique values.
+    Returns
+    -------
+    unique : ndarray
+        The sorted unique values.
+    unique_inverse : ndarray
+        The indices to reconstruct the original array from the unique array.
+        Only provided if `return_inverse` is True.
+    """
+    if values.dtype == object:
+        return _unique_python(values, return_inverse=return_inverse)
+    # numerical
+    out = np.unique(values, return_inverse=return_inverse)
+
+    if return_inverse:
+        uniques, inverse = out
+    else:
+        uniques = out
+
+    # np.unique will have duplicate missing values at the end of `uniques`
+    # here we clip the nans and remove it from uniques
+    if uniques.size and is_scalar_nan(uniques[-1]):
+        nan_idx = np.searchsorted(uniques, np.nan)
+        uniques = uniques[:nan_idx + 1]
+        if return_inverse:
+            inverse[inverse > nan_idx] = nan_idx
+
+    if return_inverse:
+        return uniques, inverse
+    return uniques
+
+
+class MissingValues(NamedTuple):
+    """Data class for missing data information"""
+    nan: bool
+    none: bool
+
+    def to_list(self):
+        """Convert tuple to a list where None is always first."""
+        output = []
+        if self.none:
+            output.append(None)
+        if self.nan:
+            output.append(np.nan)
+        return output
+
+
+def _extract_missing(values):
+    """Extract missing values from `values`.
+    Parameters
+    ----------
+    values: set
+        Set of values to extract missing from.
+    Returns
+    -------
+    output: set
+        Set with missing values extracted.
+    missing_values: MissingValues
+        Object with missing value information.
+    """
+    missing_values_set = {value for value in values
+                          if value is None or is_scalar_nan(value)}
+
+    if not missing_values_set:
+        return values, MissingValues(nan=False, none=False)
+
+    if None in missing_values_set:
+        if len(missing_values_set) == 1:
+            output_missing_values = MissingValues(nan=False, none=True)
+        else:
+            # If there is more than one missing value, then it has to be
+            # float('nan') or np.nan
+            output_missing_values = MissingValues(nan=True, none=True)
+    else:
+        output_missing_values = MissingValues(nan=True, none=False)
+
+    # create set without the missing values
+    output = values - missing_values_set
+    return output, output_missing_values
+
+
+class _nandict(dict):
+    """Dictionary with support for nans."""
+    def __init__(self, mapping):
+        super().__init__(mapping)
+        for key, value in mapping.items():
+            if is_scalar_nan(key):
+                self.nan_value = value
+                break
+
+    def __missing__(self, key):
+        if hasattr(self, 'nan_value') and is_scalar_nan(key):
+            return self.nan_value
+        raise KeyError(key)
+
+
+def _map_to_integer(values, uniques):
+    """Map values based on its position in uniques."""
+    table = _nandict({val: i for i, val in enumerate(uniques)})
+    return np.array([table[v] for v in values])
+
+
+def _unique_python(values, *, return_inverse):
+    # Only used in `_uniques`, see docstring there for details
+    try:
+        uniques_set = set(values)
+        uniques_set, missing_values = _extract_missing(uniques_set)
+
+        uniques = sorted(uniques_set)
+        uniques.extend(missing_values.to_list())
+        uniques = np.array(uniques, dtype=values.dtype)
+    except TypeError:
+        types = sorted(t.__qualname__
+                       for t in set(type(v) for v in values))
+        raise TypeError("Encoders require their input to be uniformly "
+                        f"strings or numbers. Got {types}")
+
+    if return_inverse:
+        return uniques, _map_to_integer(values, uniques)
+
+    return uniques
+
+
+def _encode(values, *, uniques, check_unknown=True):
+    """Helper function to encode values into [0, n_uniques - 1].
+    Uses pure python method for object dtype, and numpy method for
+    all other dtypes.
+    The numpy method has the limitation that the `uniques` need to
+    be sorted. Importantly, this is not checked but assumed to already be
+    the case. The calling method needs to ensure this for all non-object
+    values.
+    Parameters
+    ----------
+    values : ndarray
+        Values to encode.
+    uniques : ndarray
+        The unique values in `values`. If the dtype is not object, then
+        `uniques` needs to be sorted.
+    check_unknown : bool, default=True
+        If True, check for values in `values` that are not in `unique`
+        and raise an error. This is ignored for object dtype, and treated as
+        True in this case. This parameter is useful for
+        _BaseEncoder._transform() to avoid calling _check_unknown()
+        twice.
+    Returns
+    -------
+    encoded : ndarray
+        Encoded values
+    """
+    if values.dtype.kind in 'OU':
+        try:
+            return _map_to_integer(values, uniques)
+        except KeyError as e:
+            raise ValueError(f"y contains previously unseen labels: {str(e)}")
+    else:
+        if check_unknown:
+            diff = _check_unknown(values, uniques)
+            if diff:
+                raise ValueError(f"y contains previously unseen labels: "
+                                 f"{str(diff)}")
+        return np.searchsorted(uniques, values)
+
+
+def _check_unknown(values, known_values, return_mask=False):
+    """
+    Helper function to check for unknowns in values to be encoded.
+    Uses pure python method for object dtype, and numpy method for
+    all other dtypes.
+    Parameters
+    ----------
+    values : array
+        Values to check for unknowns.
+    known_values : array
+        Known values. Must be unique.
+    return_mask : bool, default=False
+        If True, return a mask of the same shape as `values` indicating
+        the valid values.
+    Returns
+    -------
+    diff : list
+        The unique values present in `values` and not in `know_values`.
+    valid_mask : boolean array
+        Additionally returned if ``return_mask=True``.
+    """
+    valid_mask = None
+
+    if values.dtype.kind in 'UO':
+        values_set = set(values)
+        values_set, missing_in_values = _extract_missing(values_set)
+
+        uniques_set = set(known_values)
+        uniques_set, missing_in_uniques = _extract_missing(uniques_set)
+        diff = values_set - uniques_set
+
+        nan_in_diff = missing_in_values.nan and not missing_in_uniques.nan
+        none_in_diff = missing_in_values.none and not missing_in_uniques.none
+
+        def is_valid(value):
+            return (value in uniques_set or
+                    missing_in_uniques.none and value is None or
+                    missing_in_uniques.nan and is_scalar_nan(value))
+
+        if return_mask:
+            if diff or nan_in_diff or none_in_diff:
+                valid_mask = np.array([is_valid(value) for value in values])
+            else:
+                valid_mask = np.ones(len(values), dtype=bool)
+
+        diff = list(diff)
+        if none_in_diff:
+            diff.append(None)
+        if nan_in_diff:
+            diff.append(np.nan)
+    else:
+        unique_values = np.unique(values)
+        diff = np.setdiff1d(unique_values, known_values,
+                            assume_unique=True)
+        if return_mask:
+            if diff.size:
+                valid_mask = np.in1d(values, known_values)
+            else:
+                valid_mask = np.ones(len(values), dtype=bool)
+
+        # check for nans in the known_values
+        if np.isnan(known_values).any():
+            diff_is_nan = np.isnan(diff)
+            if diff_is_nan.any():
+                # removes nan from valid_mask
+                if diff.size and return_mask:
+                    is_nan = np.isnan(values)
+                    valid_mask[is_nan] = 1
+
+                # remove nan from diff
+                diff = diff[~diff_is_nan]
+        diff = list(diff)
+
+    if return_mask:
+        return diff, valid_mask
+    return diff
+
+class _BaseEncoder(TransformerMixin, BaseEstimator):
+    """
+    Base class for encoders that includes the code to categorize and
+    transform the input features.
+    """
+
+    def _check_X(self, X, force_all_finite=True):
+        """
+        Perform custom check_array:
+        - convert list of strings to object dtype
+        - check for missing values for object dtype data (check_array does
+          not do that)
+        - return list of features (arrays): this list of features is
+          constructed feature by feature to preserve the data types
+          of pandas DataFrame columns, as otherwise information is lost
+          and cannot be used, eg for the `categories_` attribute.
+        """
+        if not (hasattr(X, 'iloc') and getattr(X, 'ndim', 0) == 2):
+            # if not a dataframe, do normal check_array validation
+            X_temp = check_array(X, dtype=None,
+                                 force_all_finite=force_all_finite)
+            if (not hasattr(X, 'dtype')
+                    and np.issubdtype(X_temp.dtype, np.str_)):
+                X = check_array(X, dtype=object,
+                                force_all_finite=force_all_finite)
+            else:
+                X = X_temp
+            needs_validation = False
+        else:
+            # pandas dataframe, do validation later column by column, in order
+            # to keep the dtype information to be used in the encoder.
+            needs_validation = force_all_finite
+
+        n_samples, n_features = X.shape
+        X_columns = []
+
+        for i in range(n_features):
+            Xi = self._get_feature(X, feature_idx=i)
+            Xi = check_array(Xi, ensure_2d=False, dtype=None,
+                             force_all_finite=needs_validation)
+            X_columns.append(Xi)
+
+        return X_columns, n_samples, n_features
+
+    def _get_feature(self, X, feature_idx):
+        if hasattr(X, 'iloc'):
+            # pandas dataframes
+            return X.iloc[:, feature_idx]
+        # numpy arrays, sparse arrays
+        return X[:, feature_idx]
+
+    def _fit(self, X, handle_unknown='error', force_all_finite=True):
+        X_list, n_samples, n_features = self._check_X(
+            X, force_all_finite=force_all_finite)
+
+        if self.categories != 'auto':
+            if len(self.categories) != n_features:
+                raise ValueError("Shape mismatch: if categories is an array,"
+                                 " it has to be of shape (n_features,).")
+
+        self.categories_ = []
+
+        for i in range(n_features):
+            Xi = X_list[i]
+            if self.categories == 'auto':
+                cats = _unique(Xi)
+            else:
+                cats = np.array(self.categories[i], dtype=Xi.dtype)
+                if Xi.dtype.kind not in 'OU':
+                    sorted_cats = np.sort(cats)
+                    error_msg = ("Unsorted categories are not "
+                                 "supported for numerical categories")
+                    # if there are nans, nan should be the last element
+                    stop_idx = -1 if np.isnan(sorted_cats[-1]) else None
+                    if (np.any(sorted_cats[:stop_idx] != cats[:stop_idx]) or
+                        (np.isnan(sorted_cats[-1]) and
+                         not np.isnan(sorted_cats[-1]))):
+                        raise ValueError(error_msg)
+
+                if handle_unknown == 'error':
+                    diff = _check_unknown(Xi, cats)
+                    if diff:
+                        msg = ("Found unknown categories {0} in column {1}"
+                               " during fit".format(diff, i))
+                        raise ValueError(msg)
+            self.categories_.append(cats)
+
+    def _transform(self, X, handle_unknown='error', force_all_finite=True):
+        X_list, n_samples, n_features = self._check_X(
+            X, force_all_finite=force_all_finite)
+
+        X_int = np.zeros((n_samples, n_features), dtype=int)
+        X_mask = np.ones((n_samples, n_features), dtype=bool)
+
+        if n_features != len(self.categories_):
+            raise ValueError(
+                "The number of features in X is different to the number of "
+                "features of the fitted data. The fitted data had {} features "
+                "and the X has {} features."
+                .format(len(self.categories_,), n_features)
+            )
+
+        for i in range(n_features):
+            Xi = X_list[i]
+            diff, valid_mask = _check_unknown(Xi, self.categories_[i],
+                                              return_mask=True)
+
+            if not np.all(valid_mask):
+                if handle_unknown == 'error':
+                    msg = ("Found unknown categories {0} in column {1}"
+                           " during transform".format(diff, i))
+                    raise ValueError(msg)
+                else:
+                    # Set the problematic rows to an acceptable value and
+                    # continue `The rows are marked `X_mask` and will be
+                    # removed later.
+                    X_mask[:, i] = valid_mask
+                    # cast Xi into the largest string type necessary
+                    # to handle different lengths of numpy strings
+                    if (self.categories_[i].dtype.kind in ('U', 'S')
+                            and self.categories_[i].itemsize > Xi.itemsize):
+                        Xi = Xi.astype(self.categories_[i].dtype)
+                    else:
+                        Xi = Xi.copy()
+
+                    Xi[~valid_mask] = self.categories_[i][0]
+            # We use check_unknown=False, since _check_unknown was
+            # already called above.
+            X_int[:, i] = _encode(Xi, uniques=self.categories_[i],
+                                  check_unknown=False)
+
+        return X_int, X_mask
+
+    def _more_tags(self):
+        return {'X_types': ['categorical']}
+    
+class OrdinalEncoder(_BaseEncoder):
+    """
+    Encode categorical features as an integer array.
+    The input to this transformer should be an array-like of integers or
+    strings, denoting the values taken on by categorical (discrete) features.
+    The features are converted to ordinal integers. This results in
+    a single column of integers (0 to n_categories - 1) per feature.
+    Read more in the :ref:`User Guide <preprocessing_categorical_features>`.
+    .. versionadded:: 0.20
+    Parameters
+    ----------
+    categories : 'auto' or a list of array-like, default='auto'
+        Categories (unique values) per feature:
+        - 'auto' : Determine categories automatically from the training data.
+        - list : ``categories[i]`` holds the categories expected in the ith
+          column. The passed categories should not mix strings and numeric
+          values, and should be sorted in case of numeric values.
+        The used categories can be found in the ``categories_`` attribute.
+    dtype : number type, default np.float64
+        Desired dtype of output.
+    handle_unknown : {'error', 'use_encoded_value'}, default='error'
+        When set to 'error' an error will be raised in case an unknown
+        categorical feature is present during transform. When set to
+        'use_encoded_value', the encoded value of unknown categories will be
+        set to the value given for the parameter `unknown_value`. In
+        :meth:`inverse_transform`, an unknown category will be denoted as None.
+        .. versionadded:: 0.24
+    unknown_value : int or np.nan, default=None
+        When the parameter handle_unknown is set to 'use_encoded_value', this
+        parameter is required and will set the encoded value of unknown
+        categories. It has to be distinct from the values used to encode any of
+        the categories in `fit`. If set to np.nan, the `dtype` parameter must
+        be a float dtype.
+        .. versionadded:: 0.24
+    Attributes
+    ----------
+    categories_ : list of arrays
+        The categories of each feature determined during ``fit`` (in order of
+        the features in X and corresponding with the output of ``transform``).
+        This does not include categories that weren't seen during ``fit``.
+    See Also
+    --------
+    OneHotEncoder : Performs a one-hot encoding of categorical features.
+    LabelEncoder : Encodes target labels with values between 0 and
+        ``n_classes-1``.
+    Examples
+    --------
+    Given a dataset with two features, we let the encoder find the unique
+    values per feature and transform the data to an ordinal encoding.
+    >>> from sklearn.preprocessing import OrdinalEncoder
+    >>> enc = OrdinalEncoder()
+    >>> X = [['Male', 1], ['Female', 3], ['Female', 2]]
+    >>> enc.fit(X)
+    OrdinalEncoder()
+    >>> enc.categories_
+    [array(['Female', 'Male'], dtype=object), array([1, 2, 3], dtype=object)]
+    >>> enc.transform([['Female', 3], ['Male', 1]])
+    array([[0., 2.],
+           [1., 0.]])
+    >>> enc.inverse_transform([[1, 0], [0, 1]])
+    array([['Male', 1],
+           ['Female', 2]], dtype=object)
+    """
+
+    @_deprecate_positional_args
+    def __init__(self, *, categories='auto', dtype=np.float64,
+                 handle_unknown='error', unknown_value=None):
+        self.categories = categories
+        self.dtype = dtype
+        self.handle_unknown = handle_unknown
+        self.unknown_value = unknown_value
+
+    def fit(self, X, y=None):
+        """
+        Fit the OrdinalEncoder to X.
+        Parameters
+        ----------
+        X : array-like, shape [n_samples, n_features]
+            The data to determine the categories of each feature.
+        y : None
+            Ignored. This parameter exists only for compatibility with
+            :class:`~sklearn.pipeline.Pipeline`.
+        Returns
+        -------
+        self
+        """
+        if self.handle_unknown == 'use_encoded_value':
+            if is_scalar_nan(self.unknown_value):
+                if np.dtype(self.dtype).kind != 'f':
+                    raise ValueError(
+                        f"When unknown_value is np.nan, the dtype "
+                        "parameter should be "
+                        f"a float dtype. Got {self.dtype}."
+                    )
+            elif not isinstance(self.unknown_value, numbers.Integral):
+                raise TypeError(f"unknown_value should be an integer or "
+                                f"np.nan when "
+                                f"handle_unknown is 'use_encoded_value', "
+                                f"got {self.unknown_value}.")
+        elif self.unknown_value is not None:
+            raise TypeError(f"unknown_value should only be set when "
+                            f"handle_unknown is 'use_encoded_value', "
+                            f"got {self.unknown_value}.")
+
+        self._fit(X)
+
+        if self.handle_unknown == 'use_encoded_value':
+            for feature_cats in self.categories_:
+                if 0 <= self.unknown_value < len(feature_cats):
+                    raise ValueError(f"The used value for unknown_value "
+                                     f"{self.unknown_value} is one of the "
+                                     f"values already used for encoding the "
+                                     f"seen categories.")
+
+        return self
+
+    def transform(self, X):
+        """
+        Transform X to ordinal codes.
+        Parameters
+        ----------
+        X : array-like, shape [n_samples, n_features]
+            The data to encode.
+        Returns
+        -------
+        X_out : sparse matrix or a 2-d array
+            Transformed input.
+        """
+        X_int, X_mask = self._transform(X, handle_unknown=self.handle_unknown)
+        X_trans = X_int.astype(self.dtype, copy=False)
+
+        # create separate category for unknown values
+        if self.handle_unknown == 'use_encoded_value':
+            X_trans[~X_mask] = self.unknown_value
+        return X_trans
+
+    def inverse_transform(self, X):
+        """
+        Convert the data back to the original representation.
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape [n_samples, n_encoded_features]
+            The transformed data.
+        Returns
+        -------
+        X_tr : array-like, shape [n_samples, n_features]
+            Inverse transformed array.
+        """
+        check_is_fitted(self)
+        X = check_array(X, accept_sparse='csr')
+
+        n_samples, _ = X.shape
+        n_features = len(self.categories_)
+
+        # validate shape of passed X
+        msg = ("Shape of the passed X data is not correct. Expected {0} "
+               "columns, got {1}.")
+        if X.shape[1] != n_features:
+            raise ValueError(msg.format(n_features, X.shape[1]))
+
+        # create resulting array of appropriate dtype
+        dt = np.find_common_type([cat.dtype for cat in self.categories_], [])
+        X_tr = np.empty((n_samples, n_features), dtype=dt)
+
+        found_unknown = {}
+
+        for i in range(n_features):
+            labels = X[:, i].astype('int64', copy=False)
+            if self.handle_unknown == 'use_encoded_value':
+                unknown_labels = labels == self.unknown_value
+                X_tr[:, i] = self.categories_[i][np.where(
+                    unknown_labels, 0, labels)]
+                found_unknown[i] = unknown_labels
+            else:
+                X_tr[:, i] = self.categories_[i][labels]
+
+        # insert None values for unknown values
+        if found_unknown:
+            X_tr = X_tr.astype(object, copy=False)
+
+            for idx, mask in found_unknown.items():
+                X_tr[mask, idx] = None
+
+        return X_tr

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_namespace_packages
 setup(
     name="accutuning_helpers",
-    version="1.0.18",
+    version="1.0.19",
     packages=find_namespace_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
문제: IntegerEncode에서 string을 int로 변환할 때, 처음 본 string이 들어오면 오류가 발생함.
(https://github.com/AIIP-DEV/accutuning/pull/820)
해결방안: transform 하려는 데이터에 fit 되지 않은 처음 본 string이 있으면 -1 (혹은 입력값)으로 변환

방법: IntegerEncode 내에서 sklearn OrdinalEncoder를 사용하는데, 여기서 unseen value에 특정 값을 부여할 수 있음.
하지만 unseen value 예외 주는 parameter가 sklearn 0.24 버전부터 있음... (지금 accutuning modeler에서 쓰는 건 0.23.2)
따라서 부득이하게 ordinalencoder_tmp.py 에 sklearn 0.24 버전의 OrdinalEncoder 코드를 뜯어와서 추가함. (sklearn 버전 올리기 전까지만 사용)