### PR TITLE
dtypeconvert - skip rather than raising error if failed

### DIFF
--- a/accutuning_helpers/preprocessing/dtypeconvert.py
+++ b/accutuning_helpers/preprocessing/dtypeconvert.py
@@ -37,7 +37,6 @@ class AccutuningDtypeConvert(BaseEstimator, TransformerMixin):
                             X_tr[col] = X[col].astype(typ)
                         except ValueError:
                             logging.critical(
-                                f'Failed to convert the datatype of column {col}.'
+                                f'Failed to convert the datatype of column {col} to {str(typ)}. Set to default.'
                             )
-                            raise
         return X_tr

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_namespace_packages
 setup(
     name="accutuning_helpers",
-    version="1.0.22",
+    version="1.0.23",
     packages=find_namespace_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
dtype 변환 실패시 에러 raise 하기 보다는 그냥 변환 전의 원dtype으로 계속 진행할 수 있도록 합니다.