### PR TITLE
화학식 변환 기능

### DIFF
--- a/accutuning_helpers/feature_engineering/__init__.py
+++ b/accutuning_helpers/feature_engineering/__init__.py
@@ -3,3 +3,4 @@ from .datetime64_converter import AccutuningDatetime64Converter  # noqa
 from .category_converter import AccutuningCategoryConverter  # noqa
 from .timeseries import AccutuningTimeseriesResample, AccutuningTimeseriesInterpolate # noqa
 from .lag_column_adder import AccutuningLagColumnAdder  # noqa
+from .chemical import AccutuningChemicalConverter   # noqa

--- a/accutuning_helpers/feature_engineering/chemical.py
+++ b/accutuning_helpers/feature_engineering/chemical.py
@@ -1,0 +1,123 @@
+import pandas as pd
+import numpy as np
+from rdkit import Chem
+from rdkit.Chem import AllChem, QED, MolFromSmiles, MolFromInchi, MolToSmiles, Descriptors, MolSurf, rdMolDescriptors
+from rdkit.Chem.AllChem import GetMorganFingerprintAsBitVect
+from rdkit.Chem.Crippen import MolLogP 
+from rdkit.Chem.QED import qed
+from sklearn.base import BaseEstimator, TransformerMixin
+import transformers
+
+import logging
+
+
+class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
+    """
+    Transform Chemical molecule string into vectors or tokens using Rdkit or transformers pretrained model.
+    
+    Parameters
+    ----------
+    feature_names : list
+        List of feature names (str) to convert
+    feature_format : str, default='smiles'
+        Molecule formats, 'smiles' or 'inchi'
+    how : str, default='ecfp'
+        Method to convert the molecule string, 'ecfp', 'fcfp' or 'tokenize'
+    dim : int, default=512
+        Dimension for the molecule conversion
+        Used only if 'how' is 'ecfp' or 'fcfp'
+    add_properties : list, default=[]
+        Add chemical properties of the input molecule columns for each.
+        'QED', 'MW', 'ALOGP', 'HBA', 'HBD', 'PSA' ...
+    """
+
+    def __init__(self, feature_names, feature_format='smiles', how='ecfp', dim=512, add_properties=[]):
+        self.feature_names = feature_names
+        self.feature_format = feature_format
+        self.how = how
+        self.dim = dim
+        self.add_properties = add_properties
+
+    def fit(self, X, y=0, **fit_params):
+        
+        if self.how == 'tokenize': 
+            from transformers import AutoTokenizer
+            self.converter = AutoTokenizer.from_pretrained('seyonec/ChemBERTa_zinc250k_v2_40k', use_fast=True)
+        else:
+            self.converter = self.how
+        
+        return self
+
+    def transform(self, X, y=0):
+        X_tr = X.copy()
+        for feature in self.feature_names:
+            target_column = X.loc[:, feature]
+        
+            converted = target_column.map(lambda x: self._convert_mol(x, 
+                                                                self.feature_format, 
+                                                                self.converter,
+                                                                self.dim))
+        
+            if self.add_properties:
+                props = target_column.map(lambda x: self._add_properties(x, self.add_properties))
+                
+            f = lambda x: 'mol_{}'.format(x + 1)
+            X_tr = X_tr.join(pd.DataFrame(converted.tolist()).rename(columns=f))
+
+        return X_tr
+
+    def _convert_mol(self, sequence, feature_format, how, dim):
+        if feature_format == 'smiles':
+            m = MolFromSmiles(sequence)
+        elif feature_format == 'inchi':
+            m = MolFromInchi(sequence)
+        else:
+            logging.critical('AutoinsightChemicalConverter: Not a valid Molecule format selected.')
+        
+        if how == 'ecfp':
+            try:
+                vec = GetMorganFingerprintAsBitVect(m, 2, nBits = dim)
+                vec = vec.ToBitString()
+            except Exception as e:
+                vec = [0] * self.dim
+                
+        elif how == 'fcfp':
+            try:
+                vec = GetMorganFingerprintAsBitVect(m, 2, useFeatures = True, nBits = dim)
+                vec = vec.ToBitString()
+            except Exception as e:
+                vec = [0] * self.dim
+
+        elif isinstance(how, transformers.tokenization_roberta.RobertaTokenizerFast):
+            smiles = MolToSmiles(m)
+            vec = how(smiles)['input_ids']
+        else:
+            logging.critical('AutoinsightChemicalConverter: No proper conversion method provided')
+        
+        converted = list(vec)
+        
+        return converted
+    
+    def _add_properties(self, mol, properties):
+        props = []
+        try:
+            pp = QED.properties(mol)
+            for i in properties:
+                if i == 'MW': 
+                    props.append(round(pp.MW, 2))
+                elif i == 'ALOGP':
+                    props.append(round(pp.ALOGP, 2))
+                elif i == 'HBA':
+                    props.append(round(pp.HBA, 2))
+                elif i == 'HBD':
+                    props.append(round(pp.HBD, 2))
+                elif i == 'PSA':
+                    props.append(round(pp.PSA, 2))
+                elif i == 'QED':
+                    props.append(round(QED.qed(mol), 2))
+                else:
+                    pass
+        except Exception as e:
+            logging.critical(f'AutoinsightChemicalConverter: Fail to get properties from smiles: {mol}')
+
+        return props

--- a/accutuning_helpers/feature_engineering/chemical.py
+++ b/accutuning_helpers/feature_engineering/chemical.py
@@ -7,9 +7,9 @@ from rdkit.Chem.Crippen import MolLogP
 from rdkit.Chem.QED import qed
 from sklearn.base import BaseEstimator, TransformerMixin
 import transformers
-
 import logging
 
+logger = logging.getLogger()
 
 class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
     """
@@ -31,7 +31,7 @@ class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
         'QED', 'MW', 'ALOGP', 'HBA', 'HBD', 'PSA' ...
     """
 
-    def __init__(self, feature_names, feature_format='smiles', how='ecfp', dim=512, add_properties=[]):
+    def __init__(self, feature_names, feature_format='smiles', how='ecfp', dim=512, add_properties=None):
         self.feature_names = feature_names
         self.feature_format = feature_format
         self.how = how
@@ -43,6 +43,7 @@ class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
         if self.how == 'tokenize': 
             from transformers import AutoTokenizer
             self.converter = AutoTokenizer.from_pretrained('seyonec/ChemBERTa_zinc250k_v2_40k', use_fast=True)
+            self.pad = self.converter.pad_token_id
         else:
             self.converter = self.how
         
@@ -52,17 +53,27 @@ class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
         X_tr = X.copy()
         for feature in self.feature_names:
             target_column = X.loc[:, feature]
+            target_idx = X.columns.get_loc(feature)
+            X_front = X.columns[:target_idx]
+            X_back = X.columns[target_idx + 1:]
         
             converted = target_column.map(lambda x: self._convert_mol(x, 
                                                                 self.feature_format, 
                                                                 self.converter,
                                                                 self.dim))
-        
+            
+            f = lambda x: '{}_{}'.format(feature, x)            
+            converted = pd.DataFrame(converted.tolist()).rename(columns=f)
+            if converted.isnull().values.any():
+                converted.fillna(self.pad, inplace=True, downcast='infer')
+
+            X_tr = pd.concat([X_tr[X_front], converted, X_tr[X_back]], axis=1)
+            
             if self.add_properties:
-                props = target_column.map(lambda x: self._add_properties(x, self.add_properties))
-                
-            f = lambda x: 'mol_{}'.format(x + 1)
-            X_tr = X_tr.join(pd.DataFrame(converted.tolist()).rename(columns=f))
+                props = target_column.map(lambda x: self._add_properties(x, 
+                                                                    self.feature_format,
+                                                                    self.add_properties))
+                X_tr = X_tr.join(pd.DataFrame.from_records(props, columns=self.add_properties))
 
         return X_tr
 
@@ -72,7 +83,8 @@ class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
         elif feature_format == 'inchi':
             m = MolFromInchi(sequence)
         else:
-            logging.critical('AutoinsightChemicalConverter: Not a valid Molecule format selected.')
+            logger.critical('AutoinsightChemicalConverter: Not a valid Molecule format selected.')
+            m = None
         
         if how == 'ecfp':
             try:
@@ -80,44 +92,54 @@ class AccutuningChemicalConverter(BaseEstimator, TransformerMixin):
                 vec = vec.ToBitString()
             except Exception as e:
                 vec = [0] * self.dim
-                
         elif how == 'fcfp':
             try:
                 vec = GetMorganFingerprintAsBitVect(m, 2, useFeatures = True, nBits = dim)
                 vec = vec.ToBitString()
             except Exception as e:
                 vec = [0] * self.dim
-
-        elif isinstance(how, transformers.tokenization_roberta.RobertaTokenizerFast):
+        elif isinstance(how, transformers.RobertaTokenizerFast):
             smiles = MolToSmiles(m)
             vec = how(smiles)['input_ids']
         else:
-            logging.critical('AutoinsightChemicalConverter: No proper conversion method provided')
+            logger.critical('AutoinsightChemicalConverter: No proper conversion method provided')
         
         converted = list(vec)
         
         return converted
     
-    def _add_properties(self, mol, properties):
+    def _add_properties(self, sequence, feature_format, properties):
         props = []
+        
+        if feature_format == 'smiles':
+            m = MolFromSmiles(sequence)
+        elif feature_format == 'inchi':
+            m = MolFromInchi(sequence)
+        else:
+            logger.critical('AutoinsightChemicalConverter: Not a valid Molecule format selected.')
+            m = None
+        
         try:
-            pp = QED.properties(mol)
-            for i in properties:
-                if i == 'MW': 
-                    props.append(round(pp.MW, 2))
-                elif i == 'ALOGP':
-                    props.append(round(pp.ALOGP, 2))
-                elif i == 'HBA':
-                    props.append(round(pp.HBA, 2))
-                elif i == 'HBD':
-                    props.append(round(pp.HBD, 2))
-                elif i == 'PSA':
-                    props.append(round(pp.PSA, 2))
-                elif i == 'QED':
-                    props.append(round(QED.qed(mol), 2))
-                else:
-                    pass
+            pp = QED.properties(m)
+            if properties:
+                for i in properties:
+                    if i == 'MW': 
+                        props.append(round(pp.MW, 2))
+                    elif i == 'ALOGP':
+                        props.append(round(pp.ALOGP, 2))
+                    elif i == 'HBA':
+                        props.append(round(pp.HBA, 2))
+                    elif i == 'HBD':
+                        props.append(round(pp.HBD, 2))
+                    elif i == 'PSA':
+                        props.append(round(pp.PSA, 2))
+                    elif i == 'QED':
+                        props.append(round(QED.qed(m), 2))
+                    else:
+                        logger.critical(f'AutoinsightChemicalConverter: Not a property available: {i}')
         except Exception as e:
-            logging.critical(f'AutoinsightChemicalConverter: Fail to get properties from smiles: {mol}')
+            props = [0] * len(properties)
+            logger.critical(f'AutoinsightChemicalConverter: Fail to get properties from smiles: {mol}')
+            logger.critical(e, exc_info=True)
 
         return props


### PR DESCRIPTION
예전에 만들어 놓고 한참 묻혀있던 화학식(smiles, inchi) 코드를 vector화 하거나 tokenize하는 기능입니다.
앞으로 쓸지 안 쓸지는 모르겠지만... 일단 pr로 공유 드립니다.

Quantum mechanics, Physical chemistry, Biophysics, Physiology 분야 데이터 적용 예시 jupyter notebook: https://github.com/kseh92/chemical_converter_notebook/blob/main/Accutuning_chemical_converter_notebook.ipynb

```
  Transform Chemical molecule string into vectors or tokens using Rdkit or transformers pretrained model.
    
    Parameters
    ----------
    feature_names : list
        List of feature names (str) to convert
    feature_format : str, default='smiles'
        Molecule formats, 'smiles' or 'inchi'
    how : str, default='ecfp'
        Method to convert the molecule string, 'ecfp', 'fcfp' or 'tokenize'
    dim : int, default=512
        Dimension for the molecule conversion
        Used only if 'how' is 'ecfp' or 'fcfp'
    add_properties : list, default=[]
        Add chemical properties of the input molecule columns for each.
        'QED', 'MW', 'ALOGP', 'HBA', 'HBD', 'PSA' ...
```