### PR TITLE
Null Imputer 기능 개선

### DIFF
--- a/accutuning_helpers/preprocessing/nullimputer.py
+++ b/accutuning_helpers/preprocessing/nullimputer.py
@@ -9,11 +9,7 @@ class AccutuningNullImputerBycol(BaseEstimator, TransformerMixin):
 
     def fit(self, X, y=0, **fit_params):
         self.strategies_dict = dict(zip(X.columns, self.impute_strategies))
-        return self
-
-    def transform(self, X, y=0):
-        X_tr = X.copy()
-        # impute_strategies는 column 순서대로 그에 해당하는 impute strategy list
+        imputing_values = []
         for col in self.strategies_dict:
             try:
                 imputing_col = X.loc[:, col]
@@ -23,27 +19,40 @@ class AccutuningNullImputerBycol(BaseEstimator, TransformerMixin):
                 )
             else:
                 strategy = self.strategies_dict[col]
-                # numerical, categorical 공통 impute 방법
-                if strategy in ('NONE', '', None):
-                    pass
-                elif strategy == 'DROP':
-                    X_tr = X_tr.dropna(how='any', subset=[col], axis=0)
-                elif strategy == 'MOST_FREQUENT':
-                    X_tr.loc[:, col] = X_tr.loc[:, col].fillna(imputing_col.mode()[0])
-                # categorical impute 방법
+                val = None
+                if strategy == 'MOST_FREQUENT':
+                    val = imputing_col.mode()[0]
                 elif strategy == 'UNKNOWN':
-                    X_tr.loc[:, col] = X_tr.loc[:, col].fillna(value='Unknown')
-                # numerical impute 방법
+                    val = 'Unknown'
                 elif is_numeric_dtype(imputing_col):
                     if strategy == 'MEAN':
-                        i_mean = imputing_col.mean()
-                        X_tr.loc[:, col] = X_tr.loc[:, col].fillna(value=i_mean)
+                        val = imputing_col.mean()
                     elif strategy == 'MEDIAN':
-                        i_median = imputing_col.median()
-                        X_tr.loc[:, col] = X_tr.loc[:, col].fillna(value=i_median)
+                        val = imputing_col.median()
                     elif strategy == 'ZERO':
-                        X_tr.loc[:, col] = X_tr.loc[:, col].fillna(value=0)
+                        val = 0
                     elif strategy == 'MINIMUM':
-                        i_min = imputing_col.min()
-                        X_tr.loc[:, col] = X_tr.loc[:, col].fillna(i_min)
+                        val = imputing_col.min()
+                imputing_values.append(val)
+        
+        self.imputing_dict = dict(zip(X.columns, imputing_values))
+        return self
+
+    def transform(self, X, y=0):
+        X_tr = X.copy()
+        # impute_strategies는 column 순서대로 그에 해당하는 impute strategy list
+        for col in self.strategies_dict:
+            imputing_val = self.imputing_dict[col]
+            strategy = self.strategies_dict[col]
+            # numerical, categorical 공통 impute 방법
+            if strategy in ('NONE', '', None):
+                pass
+            elif strategy == 'DROP':
+                X_tr = X_tr.dropna(how='any', subset=[col], axis=0)
+            # categorical impute 방법
+            elif strategy == 'UNKNOWN':
+                X_tr.loc[:, col] = X_tr.loc[:, col].fillna(value='Unknown')
+            # numerical impute 방법
+            elif strategy in ('MOST_FREQUENT', 'Unknown', 'MEAN', 'MEDIAN', 'ZERO', 'MINIMUM') and imputing_val is not None:
+                X_tr.loc[:, col] = X_tr.loc[:, col].fillna(imputing_val)
         return X_tr

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_namespace_packages
 setup(
     name="accutuning_helpers",
-    version="1.0.23",
+    version="1.0.24",
     packages=find_namespace_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
Null Imputer를 사용하여 Mean, Median, Mostfrequent 등 imputation을 할 때, train / valid / test set 모두 train set 에서 구한 값으로 채워넣도록 합니다. 
전처리 과정에서 Valid, Test set에서 얻은 정보는 활용하면 안되기 때문입니다 - Target Leakage 방지 차원

Train set을 Fit 할 때 채워넣을 값을 저장해놓고, valid, test 대상으로 transform 할 때 저장해놓은 값을 가져와서 채워넣습니다.