### PR TITLE
BUGFIX: input raw 수 -> vector의 raw 불일치 및 df 내부 NaN 발생 수정

### DIFF
--- a/tests/text/test_embedder_tfidf.py
+++ b/tests/text/test_embedder_tfidf.py
@@ -1,8 +1,8 @@
 import os
+import pickle
 from unittest import TestCase
 
 import pandas as pd
-import pickle
 
 from accutuning_helpers.text.embedder_tfidf import TfIdfTokenVectorizer
 from accutuning_helpers.text.tokenizer import KonlpyTokenizer
@@ -14,54 +14,59 @@ class TestTfidfTokenVectorizer(TestCase):
 		home = os.environ['ACCUTUNING_WORKSPACE']
 		# datafile = os.path.join(home, 'data/naver_movie_comments_data_small.txt')
 		# df = pd.read_csv(datafile, sep='\t', header=None, names=['movie_ids', 'comments', 'rates'])
-		datafile = os.path.join(home, 'data/nnst_lt_10.csv')
-		self.df = pd.read_csv(datafile)
+		# datafile = os.path.join(home, 'data/nnst_lt_1990.csv')
+		datafile = os.path.join(home, 'data/네이버영화평_sample.csv')
+		df = pd.read_csv(datafile)
+		self.train_df = df.iloc[:400]
+		self.valid_df = df.iloc[400:]
+		self.df = pd.concat([self.train_df, self.valid_df])
 
 		self.tokenizer = KonlpyTokenizer(tokenizer_name='mecab')
 		# self.embedder = TfIdfTokenVectorizer(feature_name='comments', tokenizer=self.tokenizer)
-		self.embedder = TfIdfTokenVectorizer(feature_name='stcs', tokenizer=self.tokenizer, min_df=0)
+		# self.embedder = TfIdfTokenVectorizer(feature_name='stcs', tokenizer=self.tokenizer, min_df=0)
+		self.embedder = TfIdfTokenVectorizer(feature_name='document', tokenizer=self.tokenizer, min_df=0)
 
 	def test_tokenize(self):
 		assert len(self.df) > 0
 		# comments = self.df['comments']
-		comments = self.df['stcs']
+		# comments = self.df['stcs']
+		comments = self.df['document']
 		comment = comments[0]
 
 		tokens = self.tokenizer(comment)
 		print(f'tokens:{tokens}')
-		# assert tokens == ['크리스토퍼', '놀란', '우리', '놀란', '다']
+
+	# assert tokens == ['크리스토퍼', '놀란', '우리', '놀란', '다']
 
 	def test_fit(self):
-		X = self.df
-		self.embedder.fit(X)
+		self.embedder.fit(self.df)
 		print(f'\nvocab lenghth:{self.embedder.embedding_length}')
 		# assert self.embedder.embedding_length == 9994
-		assert self.embedder.embedding_length == 74
+		# assert self.embedder.embedding_length == 74
 		vocab = self.embedder._vectorizer.vocabulary_
 		keywords = sorted(vocab.keys(), key=lambda x: vocab[x], reverse=True)
 		print(keywords[:5])
-		# assert '힙' in keywords[:5]
-		assert '해' in keywords[:5]
+		assert len(vocab.keys()) > 0
 
 	def test_transform(self):
-		X = self.df
 		if self.embedder.embedding_length == 0:
-			self.embedder.fit(X)
+			self.embedder.fit(self.df)
 
-		vec = self.embedder.transform(X)
-		# print(f'vector:{vec}')
+		vec = self.embedder.transform(self.valid_df)
+		print(f'vector:{vec}')
 		print(f'vector.shape:{vec.shape}')
 		# assert vec.shape[1] == 9994
-		assert vec.shape[1] == 76
+		assert len(self.valid_df) == vec.shape[0]
 
 	def test_fit_transform(self):
 		X = self.df
 		vec = self.embedder.fit_transform(X)
 		print(f'\nvocab lenghth:{self.embedder.embedding_length}')
 		# assert self.embedder.embedding_length == 9994
-		assert self.embedder.embedding_length == 74
+		# assert self.embedder.embedding_length == 74
 		print(f'vector:{vec}')
 		print(f'vector.shape:{vec.shape}')
+		assert len(X) == vec.shape[0]
 
 	def test_save(self):
 		with open('test_dump.pkl', 'wb') as f:


### PR DESCRIPTION
pd.concat 으로 외부 datafame과 tfidf vector (csr matrix 기반 dataframe)을 concat하려고 할때 예상과 달리,
axis 1 에 붙지 않고  raw 2배가 됨
-> numpy로 붙이고, 다시 해당 데이터를 dataframe화 하는 식으로 수정